### PR TITLE
use counter for filenames

### DIFF
--- a/Model/PasteFileModel.php
+++ b/Model/PasteFileModel.php
@@ -57,22 +57,20 @@ class PasteFileModel extends FileModel
 
     public function moveImagesToTask($taskId)
     {
+        $imagenumber = 0;
         $task = $this->taskFinderModel->getById($taskId);
 
         $description = $task['description'];
         $needle = '<PITM:';
         $found = strpos($description, $needle);
 
-        if ($found !== false)
-        {
+        if ($found !== false) {
             $needleEnd = '>';
-            while ($found !== false)
-            {
+            while ($found !== false) {
                 $start = $found + 6;
                 $end = strpos($description, $needleEnd, $start);
 
-                if ($end === false)
-                {
+                if ($end === false) {
                     return;
                 }
 
@@ -83,16 +81,14 @@ class PasteFileModel extends FileModel
                 $fileName = substr($description, $start, $fileNameLenght);
                 $link = '';
 
-                try
-                {
+                try {
+                    ++$imagenumber;
                     $data = $this->objectStorage->get($fileName);
                     $this->objectStorage->remove($fileName);
-                    $filePath = $this->taskFileModel->uploadScreenshot($taskId, $data);
+                    $filePath = $this->taskFileModel->uploadContent($taskId, $imagenumber . ".png", $data);
 
                     $link = '<img src="?controller=FileViewerController&action=image&task_id=' . $taskId . '&file_id=' . $filePath . '" class="enlargable" />';
-                }
-                catch (ObjectStorageException $e)
-                {
+                } catch (ObjectStorageException $e) {
                     $this->logger->error($e->getMessage());
                 }
 

--- a/Plugin.php
+++ b/Plugin.php
@@ -42,7 +42,7 @@ class Plugin extends Base
 
     public function getPluginVersion()
     {
-        return '1.0.0';
+        return '1.0.1';
     }
 
     public function getPluginDescription()


### PR DESCRIPTION
If there were multiple images uploaded in the same to-be-created task, there was a high probability to only get one file as a result as the filemodel saves them all to the same timestamp-filename.

this now uses a separate counter for the files to avoid the conflicting paths.